### PR TITLE
Implement 3-column layout for teams page

### DIFF
--- a/src/app/dashboard/leagues/[id]/teams/page.tsx
+++ b/src/app/dashboard/leagues/[id]/teams/page.tsx
@@ -6,11 +6,20 @@ import withRoleAuth from "@/components/auth/withRoleAuth";
 import { ROLES } from "@/lib/auth/role-utils";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { ArrowLeft, Users, Plus } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { ArrowLeft, Users, Plus, X, UserPlus, RefreshCw, Search } from "lucide-react";
 import Link from "next/link";
 import { toast } from "sonner";
-import { TeamCreationForm } from "@/components/admin/TeamCreationForm";
+import { getRandomTeamName } from "@/utils/teamNameSuggestions";
 
 interface Player {
   id: string;
@@ -19,6 +28,7 @@ interface Player {
   skillLevel: number;
   handedness: string;
   preferredPosition: string;
+  email?: string;
 }
 
 interface Team {
@@ -30,87 +40,445 @@ interface Team {
   createdBy: string;
 }
 
+// Component for the Available Players column
+function AvailablePlayersColumn({ onAddPlayer }: { onAddPlayer: (player: Player) => void }) {
+  const [availablePlayers, setAvailablePlayers] = useState<Player[]>([]);
+  const [isLoadingPlayers, setIsLoadingPlayers] = useState(true);
+  const [searchTerm, setSearchTerm] = useState("");
+
+  useEffect(() => {
+    fetchPlayers();
+  }, []);
+
+  async function fetchPlayers() {
+    try {
+      setIsLoadingPlayers(true);
+      let url = '/api/admin/players?status=active';
+      
+      const response = await fetch(url);
+      
+      if (!response.ok) {
+        throw new Error("Failed to fetch players");
+      }
+      
+      const data = await response.json();
+      
+      if (data.players) {
+        // Process the players to ensure IDs are normalized
+        const processedPlayers = data.players.map((player: any) => ({
+          ...player,
+          id: player._id || player.id
+        }));
+        setAvailablePlayers(processedPlayers);
+      }
+    } catch (error) {
+      console.error("Error fetching players:", error);
+      toast.error("Failed to load players");
+    } finally {
+      setIsLoadingPlayers(false);
+    }
+  }
+
+  const handleSearch = async () => {
+    if (!searchTerm.trim()) {
+      toast.error("Please enter a search term");
+      return;
+    }
+    
+    try {
+      setIsLoadingPlayers(true);
+      
+      const searchType = searchTerm.includes('@') ? 'email' : 'nickname';
+      const url = `/api/admin/players?${searchType}=${encodeURIComponent(searchTerm)}`;
+      
+      const response = await fetch(url);
+      
+      if (!response.ok) {
+        throw new Error("Failed to search players");
+      }
+      
+      const data = await response.json();
+      
+      if (data.players) {
+        // Process the players to ensure IDs are normalized
+        const processedPlayers = data.players.map((player: any) => ({
+          ...player,
+          id: player._id || player.id
+        }));
+        setAvailablePlayers(processedPlayers);
+      }
+    } catch (error) {
+      console.error("Error searching players:", error);
+      toast.error("Failed to search players");
+    } finally {
+      setIsLoadingPlayers(false);
+    }
+  };
+
+  return (
+    <Card className="h-full">
+      <CardHeader>
+        <CardTitle>Available Players</CardTitle>
+        <CardDescription>
+          Select players to add to your team
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex space-x-2 mb-3">
+          <Input 
+            value={searchTerm}
+            onChange={e => setSearchTerm(e.target.value)}
+            placeholder="Search players by nickname or email"
+            className="flex-1"
+          />
+          <Button onClick={handleSearch} type="button">
+            <Search className="h-4 w-4 mr-2" />
+            Search
+          </Button>
+        </div>
+        
+        <div className="border rounded-md overflow-hidden">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Nickname</TableHead>
+                <TableHead>Skill</TableHead>
+                <TableHead className="w-[100px]">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isLoadingPlayers ? (
+                <TableRow>
+                  <TableCell colSpan={3} className="text-center">
+                    <div className="py-8 text-muted-foreground animate-pulse">
+                      Loading players...
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ) : availablePlayers.length > 0 ? (
+                availablePlayers.map(player => (
+                  <TableRow key={player.id}>
+                    <TableCell className="font-medium">{player.nickname}</TableCell>
+                    <TableCell>{player.skillLevel}</TableCell>
+                    <TableCell>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-8"
+                        onClick={() => onAddPlayer(player)}
+                      >
+                        <Plus className="h-4 w-4 mr-1" />
+                        Add
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={3} className="text-center">
+                    <div className="py-8 text-muted-foreground">
+                      No players found
+                    </div>
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// Component for the Create Team column
+function CreateTeamColumn({ 
+  leagueId, 
+  selectedPlayers, 
+  setSelectedPlayers, 
+  onTeamCreated 
+}: { 
+  leagueId: string, 
+  selectedPlayers: Player[],
+  setSelectedPlayers: React.Dispatch<React.SetStateAction<Player[]>>,
+  onTeamCreated: () => void 
+}) {
+  const [teamName, setTeamName] = useState(getRandomTeamName());
+  const [isCreating, setIsCreating] = useState(false);
+
+  // Remove player from team
+  const removePlayerFromTeam = (playerId: string) => {
+    setSelectedPlayers(selectedPlayers.filter(p => p.id !== playerId));
+  };
+
+  // Generate a new random team name
+  const generateRandomName = () => {
+    setTeamName(getRandomTeamName());
+  };
+
+  // Create the team
+  const handleCreateTeam = async () => {
+    if (!teamName.trim()) {
+      toast.error("Please enter a team name");
+      return;
+    }
+    
+    if (selectedPlayers.length === 0) {
+      toast.error("Please select at least one player for the team");
+      return;
+    }
+    
+    try {
+      setIsCreating(true);
+      
+      const response = await fetch(`/api/leagues/${leagueId}/teams`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          name: teamName,
+          players: selectedPlayers.map(p => p.id),
+        }),
+      });
+      
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || 'Failed to create team');
+      }
+      
+      toast.success("Team created successfully");
+      
+      // Reset form
+      setTeamName(getRandomTeamName());
+      setSelectedPlayers([]);
+      
+      // Callback
+      onTeamCreated();
+    } catch (error) {
+      console.error('Error creating team:', error);
+      toast.error(error instanceof Error ? error.message : 'Failed to create team');
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  return (
+    <Card className="h-full">
+      <CardHeader>
+        <CardTitle>Create Team</CardTitle>
+        <CardDescription>
+          Define your team with selected players
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {/* Team Name */}
+        <div className="space-y-2">
+          <Label>Team Name</Label>
+          <div className="flex space-x-2">
+            <Input 
+              value={teamName} 
+              onChange={e => setTeamName(e.target.value)}
+              placeholder="Enter team name"
+              className="flex-1"
+            />
+            <Button type="button" variant="outline" onClick={generateRandomName}>
+              <span className="sr-only">Generate Random Name</span>
+              <RefreshCw className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+        
+        {/* Selected Players */}
+        <div className="space-y-2">
+          <Label>Team Members</Label>
+          <div className="border rounded-md p-4">
+            {selectedPlayers.length === 0 ? (
+              <div className="text-center text-muted-foreground py-6">
+                <UserPlus className="h-10 w-10 mx-auto mb-2 opacity-20" />
+                <p>No players added yet</p>
+                <p className="text-sm">Select players from the left column</p>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {selectedPlayers.map(player => (
+                  <div key={player.id} className="flex items-center justify-between bg-muted p-3 rounded-md">
+                    <div className="flex items-center">
+                      <div className="bg-primary/10 text-primary h-8 w-8 rounded-full flex items-center justify-center font-medium mr-3">
+                        {player.nickname.charAt(0).toUpperCase()}
+                      </div>
+                      <div>
+                        <div className="font-medium">{player.nickname}</div>
+                        <div className="text-xs text-muted-foreground">
+                          Skill: {player.skillLevel} • 
+                          {player.handedness === 'right' ? 'Right-handed' : 
+                           player.handedness === 'left' ? 'Left-handed' : 'Ambidextrous'}
+                        </div>
+                      </div>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-8 w-8 p-0"
+                      onClick={() => removePlayerFromTeam(player.id)}
+                    >
+                      <X className="h-4 w-4" />
+                      <span className="sr-only">Remove</span>
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+        
+        <Button 
+          onClick={handleCreateTeam} 
+          disabled={isCreating || selectedPlayers.length === 0 || !teamName.trim()}
+          className="w-full"
+        >
+          {isCreating ? 'Creating...' : 'Create Team'}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+// Component for the Teams in League column
+function TeamsInLeagueColumn({ teams }: { teams: Team[] }) {
+  return (
+    <Card className="h-full">
+      <CardHeader>
+        <CardTitle>Teams in This League</CardTitle>
+        <CardDescription>
+          {teams.length} team{teams.length !== 1 ? 's' : ''} in this league
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {teams.length > 0 ? (
+          <div className="space-y-4">
+            {teams.map(team => (
+              <Card key={team.id} className="overflow-hidden">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-lg">{team.name}</CardTitle>
+                  <CardDescription>
+                    {team.players.length === 1 ? "1 player" : `${team.players.length} players`}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-2">
+                    {team.players.map(player => (
+                      <div key={player.id} className="flex items-center p-2 bg-muted rounded-md">
+                        <div className="bg-primary/10 text-primary h-8 w-8 rounded-full flex items-center justify-center font-medium mr-2">
+                          {player.nickname.charAt(0).toUpperCase()}
+                        </div>
+                        <div>
+                          <div className="font-medium">{player.nickname}</div>
+                          <div className="text-xs text-muted-foreground">
+                            Skill: {player.skillLevel} • 
+                            {player.handedness === 'right' ? 'Right' : 
+                             player.handedness === 'left' ? 'Left' : 'Ambi'}
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                    
+                    {team.players.length < 2 && (
+                      <div className="text-center p-2 border border-dashed rounded-md text-sm text-muted-foreground">
+                        Team needs one more player
+                      </div>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-12">
+            <Users className="h-12 w-12 mx-auto text-muted-foreground/30 mb-4" />
+            <h3 className="text-lg font-medium mb-2">No Teams Yet</h3>
+            <p className="text-muted-foreground mb-4">
+              This league doesn't have any teams yet. Create teams to get started.
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 function LeagueTeamsPage() {
   const params = useParams();
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(true);
   const [league, setLeague] = useState<any>(null);
   const [teams, setTeams] = useState<Team[]>([]);
-  const [activeTab, setActiveTab] = useState("existing");
+  const [selectedPlayers, setSelectedPlayers] = useState<Player[]>([]);
   
   const leagueId = params.id as string;
   
   useEffect(() => {
-    async function fetchLeagueData() {
-      try {
-        setIsLoading(true);
-        
-        // Fetch league details
-        const leagueResponse = await fetch(`/api/leagues/${leagueId}`);
-        if (!leagueResponse.ok) {
-          throw new Error('Failed to fetch league details');
-        }
-        
-        const leagueData = await leagueResponse.json();
-        setLeague(leagueData);
-        
-        // Fetch teams in this league
-        const teamsResponse = await fetch(`/api/leagues/${leagueId}/teams`);
-        if (!teamsResponse.ok) {
-          throw new Error('Failed to fetch teams');
-        }
-        
-        const teamsData = await teamsResponse.json();
-        
-        if (teamsData.teams) {
-          // Normalize team IDs
-          const processedTeams = teamsData.teams.map((team: any) => ({
-            ...team,
-            id: team._id || team.id,
-            players: (team.players || []).map((player: any) => ({
-              ...player,
-              id: player._id || player.id
-            }))
-          }));
-          
-          setTeams(processedTeams);
-        }
-      } catch (error) {
-        console.error("Error fetching league data:", error);
-        toast.error("Failed to load league and team data");
-      } finally {
-        setIsLoading(false);
-      }
-    }
-    
     fetchLeagueData();
   }, [leagueId]);
   
+  async function fetchLeagueData() {
+    try {
+      setIsLoading(true);
+      
+      // Fetch league details
+      const leagueResponse = await fetch(`/api/leagues/${leagueId}`);
+      if (!leagueResponse.ok) {
+        throw new Error('Failed to fetch league details');
+      }
+      
+      const leagueData = await leagueResponse.json();
+      setLeague(leagueData);
+      
+      // Fetch teams in this league
+      const teamsResponse = await fetch(`/api/leagues/${leagueId}/teams`);
+      if (!teamsResponse.ok) {
+        throw new Error('Failed to fetch teams');
+      }
+      
+      const teamsData = await teamsResponse.json();
+      
+      if (teamsData.teams) {
+        // Normalize team IDs
+        const processedTeams = teamsData.teams.map((team: any) => ({
+          ...team,
+          id: team._id || team.id,
+          players: (team.players || []).map((player: any) => ({
+            ...player,
+            id: player._id || player.id
+          }))
+        }));
+        
+        setTeams(processedTeams);
+      }
+    } catch (error) {
+      console.error("Error fetching league data:", error);
+      toast.error("Failed to load league and team data");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+  
   const handleTeamCreated = () => {
     // Refresh teams list
-    fetch(`/api/leagues/${leagueId}/teams`)
-      .then(response => response.json())
-      .then(data => {
-        if (data.teams) {
-          // Normalize team IDs
-          const processedTeams = data.teams.map((team: any) => ({
-            ...team,
-            id: team._id || team.id,
-            players: (team.players || []).map((player: any) => ({
-              ...player,
-              id: player._id || player.id
-            }))
-          }));
-          
-          setTeams(processedTeams);
-          
-          // Switch to existing teams tab
-          setActiveTab("existing");
-        }
-      })
-      .catch(error => {
-        console.error("Error refreshing teams:", error);
-      });
+    fetchLeagueData();
+  };
+  
+  const addPlayerToTeam = (player: Player) => {
+    if (selectedPlayers.length >= 2) {
+      toast.error("A team can have at most 2 players");
+      return;
+    }
+    
+    if (selectedPlayers.some(p => p.id === player.id)) {
+      toast.error("This player is already in the team");
+      return;
+    }
+    
+    setSelectedPlayers([...selectedPlayers, player]);
   };
   
   if (isLoading) {
@@ -152,89 +520,27 @@ function LeagueTeamsPage() {
         <p className="text-muted-foreground mt-1">Team Management</p>
       </div>
       
-      <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
-        <TabsList>
-          <TabsTrigger value="existing">
-            <Users className="h-4 w-4 mr-2" />
-            Existing Teams ({teams.length})
-          </TabsTrigger>
-          <TabsTrigger value="create">
-            <Plus className="h-4 w-4 mr-2" />
-            Create Team
-          </TabsTrigger>
-        </TabsList>
+      <div className="grid lg:grid-cols-3 gap-6">
+        {/* Column 1: Available Players */}
+        <div className="lg:col-span-1">
+          <AvailablePlayersColumn onAddPlayer={addPlayerToTeam} />
+        </div>
         
-        <TabsContent value="existing">
-          <Card>
-            <CardHeader>
-              <CardTitle>Teams in {league.name}</CardTitle>
-              <CardDescription>
-                Manage existing teams in this league
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              {teams.length > 0 ? (
-                <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-                  {teams.map(team => (
-                    <Card key={team.id} className="overflow-hidden">
-                      <CardHeader className="pb-2">
-                        <CardTitle className="text-lg">{team.name}</CardTitle>
-                        <CardDescription>
-                          {team.players.length === 1 ? "1 player" : `${team.players.length} players`}
-                        </CardDescription>
-                      </CardHeader>
-                      <CardContent>
-                        <div className="space-y-2">
-                          {team.players.map(player => (
-                            <div key={player.id} className="flex items-center p-2 bg-muted rounded-md">
-                              <div className="bg-primary/10 text-primary h-8 w-8 rounded-full flex items-center justify-center font-medium mr-2">
-                                {player.nickname.charAt(0).toUpperCase()}
-                              </div>
-                              <div>
-                                <div className="font-medium">{player.nickname}</div>
-                                <div className="text-xs text-muted-foreground">
-                                  Skill: {player.skillLevel} • 
-                                  {player.handedness === 'right' ? 'Right' : 
-                                   player.handedness === 'left' ? 'Left' : 'Ambi'}
-                                </div>
-                              </div>
-                            </div>
-                          ))}
-                          
-                          {team.players.length < 2 && (
-                            <div className="text-center p-2 border border-dashed rounded-md text-sm text-muted-foreground">
-                              Team needs one more player
-                            </div>
-                          )}
-                        </div>
-                      </CardContent>
-                    </Card>
-                  ))}
-                </div>
-              ) : (
-                <div className="text-center py-12">
-                  <Users className="h-12 w-12 mx-auto text-muted-foreground/30 mb-4" />
-                  <h3 className="text-lg font-medium mb-2">No Teams Yet</h3>
-                  <p className="text-muted-foreground mb-4">
-                    This league doesn't have any teams yet. Create teams to get started.
-                  </p>
-                  <Button onClick={() => setActiveTab("create")}>
-                    <Plus className="h-4 w-4 mr-2" />
-                    Create Team
-                  </Button>
-                </div>
-              )}
-            </CardContent>
-          </Card>
-        </TabsContent>
-        
-        <TabsContent value="create">
-          <TeamCreationForm 
-            leagueId={leagueId} 
+        {/* Column 2: Create Team */}
+        <div className="lg:col-span-1">
+          <CreateTeamColumn 
+            leagueId={leagueId}
+            selectedPlayers={selectedPlayers}
+            setSelectedPlayers={setSelectedPlayers}
             onTeamCreated={handleTeamCreated}
           />
-        </TabsContent>
-      </Tabs>
+        </div>
+        
+        {/* Column 3: Teams in This League */}
+        <div className="lg:col-span-1">
+          <TeamsInLeagueColumn teams={teams} />
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
This PR enhances the teams management page to display all elements in a 3-column layout:

1. First column: Available Players - Lists all players that can be selected for teams
2. Second column: Create Team - UI for selecting players and creating a team
3. Third column: Teams in This League - Displays all existing teams

This layout makes it easier to view all available options simultaneously without switching tabs, improving the admin user experience when managing teams.

Changes:
- Reorganized the teams page to use a grid layout with three columns
- Split functionality into three component functions for better organization
- Maintained all existing functionality while improving the UI
- Made the layout responsive for different screen sizes
- Simplified the team creation process by allowing direct selection from available players