### PR TITLE
Rebrand to Padeliga

### DIFF
--- a/.env.local.template
+++ b/.env.local.template
@@ -7,9 +7,9 @@ NODE_ENV=development
 
 # Database Configuration
 # MongoDB Connection URI (REQUIRED)
-MONGODB_URI=mongodb://localhost:27017/casino_liga
-# Optional: Specify database name explicitly (defaults to 'casino_liga' if not set)
-MONGODB_DATABASE=casino_liga
+MONGODB_URI=mongodb://localhost:27017/padeliga
+# Optional: Specify database name explicitly (defaults to 'padeliga' if not set)
+MONGODB_DATABASE=padeliga
 
 # NextAuth Configuration
 # Secret for JWT encryption (REQUIRED - at least 32 characters)

--- a/IMPLEMENTATION-STATUS.md
+++ b/IMPLEMENTATION-STATUS.md
@@ -14,7 +14,7 @@
 
 ## Admin Flow
 
-The admin flow for managing a padel league in Casino Liga is as follows:
+The admin flow for managing a padel league in Padeliga is as follows:
 
 1. **Create a League**
    - Set league details (name, description, dates)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Casino Liga
+# Padeliga
+
+*Tu liga. Tu juego.*
 
 A management system for padel leagues and tournaments.
 
@@ -31,7 +33,7 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 This application requires MongoDB. By default, it connects to a local MongoDB instance at:
 
 ```
-mongodb://localhost:27017/casino_liga
+mongodb://localhost:27017/padeliga
 ```
 
 To use a different MongoDB instance, set the `MONGODB_URI` environment variable in your `.env.local` file.

--- a/REBRANDING.md
+++ b/REBRANDING.md
@@ -1,0 +1,34 @@
+# Rebranding to "Padeliga"
+
+*Tu liga. Tu juego.*
+
+## Summary of Changes
+
+This branch implements the rebranding of the application from "Casino Liga" to "Padeliga" with the new tagline "Tu liga. Tu juego." (Your league. Your game.).
+
+The following changes have been made:
+
+### Documentation Updates
+- Updated README.md with new brand name and tagline
+- Updated SETUP.md with new brand name and references
+- Updated IMPLEMENTATION-STATUS.md with new brand name
+- Updated package.json with new project name
+
+### Configuration Updates
+- Updated .env.local.template with new database name
+- Updated database configuration in src/config/database/loader.ts to use "padeliga" as default database name
+
+### UI Components
+- Updated layout.tsx metadata with new title and tagline
+- Enhanced PageHeader.tsx to display the tagline under the logo
+- Updated AuthLogo.tsx to include the new brand name and tagline
+
+## Next Steps
+
+After merging this branch, the following additional steps are recommended:
+
+1. Update the repository name from "casino-liga" to "padeliga"
+2. Create a new logo that reflects the "Padeliga" brand identity
+3. Update any deployment scripts or CI/CD configurations with the new name
+4. Update any documentation or marketing materials with the new branding
+5. Consider updating the domain name if applicable

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,6 +1,8 @@
-# Padel League Setup Guide
+# Padeliga Setup Guide
 
-This guide will help you set up the Padel League application on your local development environment.
+*Tu liga. Tu juego.*
+
+This guide will help you set up the Padeliga application on your local development environment.
 
 ## Prerequisites
 
@@ -14,8 +16,8 @@ This guide will help you set up the Padel League application on your local devel
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/morhendos/padel-league.git
-cd padel-league
+git clone https://github.com/morhendos/padeliga.git
+cd padeliga
 ```
 
 ### 2. Install Dependencies
@@ -56,8 +58,8 @@ The application is built using Next.js and follows a clean architecture:
 
 - **Models**: MongoDB schemas for all data entities (players, teams, leagues, matches, rankings)
 - **API Routes**: RESTful endpoints for data operations
-- **Components**: UI components for the frontend (to be implemented)
-- **Pages**: Next.js pages for the frontend (to be implemented)
+- **Components**: UI components for the frontend
+- **Pages**: Next.js pages for the frontend
 
 ## API Routes
 

--- a/docs/ADMIN-INVITATION-FLOW.md
+++ b/docs/ADMIN-INVITATION-FLOW.md
@@ -1,6 +1,6 @@
 # Admin Invitation Flow: Testing Guide
 
-This document provides a step-by-step guide for testing the new player invitation system in the Casino Liga application.
+This document provides a step-by-step guide for testing the new player invitation system in the Padeliga application.
 
 ## Prerequisites
 

--- a/docs/ADMIN-WORKFLOW-CHECKLIST.md
+++ b/docs/ADMIN-WORKFLOW-CHECKLIST.md
@@ -1,6 +1,6 @@
 # Admin Workflow Implementation Progress
 
-This document tracks the implementation status of the role-based access control and admin workflow features in the Casino Liga application.
+This document tracks the implementation status of the role-based access control and admin workflow features in the Padeliga application.
 
 ## 1. Data Model Adjustments
 

--- a/docs/GAME-CREATION-FEATURE.md
+++ b/docs/GAME-CREATION-FEATURE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document describes the changes made to separate game creation from schedule generation in the Casino Liga platform. The goal is to improve flexibility by allowing admins to create individual games manually, with schedule generation being an optional feature.
+This document describes the changes made to separate game creation from schedule generation in the Padeliga platform. The goal is to improve flexibility by allowing admins to create individual games manually, with schedule generation being an optional feature.
 
 ## Motivation
 

--- a/docs/LEAGUE-ANALYTICS-FEATURES.md
+++ b/docs/LEAGUE-ANALYTICS-FEATURES.md
@@ -1,6 +1,6 @@
 # League Analytics Features
 
-This document outlines the analytics and reporting features implemented in the Casino Liga application to provide insights into league performance, player statistics, and administrative reporting capabilities.
+This document outlines the analytics and reporting features implemented in the Padeliga application to provide insights into league performance, player statistics, and administrative reporting capabilities.
 
 ## 1. League Statistics Dashboard
 

--- a/docs/LEAGUE-DELETION-FEATURE-PLAN.md
+++ b/docs/LEAGUE-DELETION-FEATURE-PLAN.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document outlines the plan for implementing a feature that allows administrators to delete leagues they have created in the Casino Liga application. League deletion is a sensitive operation that requires careful implementation to prevent data loss, ensure proper permissions, and maintain application integrity.
+This document outlines the plan for implementing a feature that allows administrators to delete leagues they have created in the Padeliga application. League deletion is a sensitive operation that requires careful implementation to prevent data loss, ensure proper permissions, and maintain application integrity.
 
 ## Feature Requirements
 
@@ -232,4 +232,4 @@ This document outlines the plan for implementing a feature that allows administr
 
 ## Conclusion
 
-The league deletion feature will provide administrators with the necessary control over the lifecycle of leagues while ensuring data integrity and preventing accidental data loss. By implementing a careful balance of security, user experience, and data management, this feature will enhance the administrative capabilities of the Casino Liga application.
+The league deletion feature will provide administrators with the necessary control over the lifecycle of leagues while ensuring data integrity and preventing accidental data loss. By implementing a careful balance of security, user experience, and data management, this feature will enhance the administrative capabilities of the Padeliga application.

--- a/docs/LEAGUE-MANAGEMENT-IMPLEMENTATION-PLAN.md
+++ b/docs/LEAGUE-MANAGEMENT-IMPLEMENTATION-PLAN.md
@@ -1,6 +1,6 @@
 # League Management Implementation Plan
 
-This document outlines the plan for completing the League creation and management functionality for admin users in Casino Liga, with checkboxes to track progress.
+This document outlines the plan for completing the League creation and management functionality for admin users in Padeliga, with checkboxes to track progress.
 
 ## Current State
 

--- a/docs/MATCH-RESULT-RECORDING-FEATURES.md
+++ b/docs/MATCH-RESULT-RECORDING-FEATURES.md
@@ -1,6 +1,6 @@
 # Match Result Recording Features
 
-This document outlines the match result recording functionality implemented in Casino Liga.
+This document outlines the match result recording functionality implemented in Padeliga.
 
 ## Overview
 

--- a/docs/PLAYER-TEAM-LEAGUE-FLOW.md
+++ b/docs/PLAYER-TEAM-LEAGUE-FLOW.md
@@ -4,7 +4,7 @@ This document explains how to use the admin functionality to create and manage p
 
 ## Overview
 
-The Casino Liga system allows administrators to:
+The Padeliga system allows administrators to:
 
 1. Create players directly within league management
 2. Create leagues with detailed settings

--- a/docs/ROLE-BASED-ACCESS-PLAN.md
+++ b/docs/ROLE-BASED-ACCESS-PLAN.md
@@ -1,6 +1,6 @@
-# Implementation Plan: Role-Based Access Control for Casino Liga
+# Implementation Plan: Role-Based Access Control for Padeliga
 
-This document outlines the comprehensive plan to implement role-based access control in the Casino Liga application, with two main roles:
+This document outlines the comprehensive plan to implement role-based access control in the Padeliga application, with two main roles:
 - **Admin users**: Can create and manage leagues, and have full access to all features
 - **Player users**: Can only see and interact with leagues they're part of
 

--- a/docs/ROLE-USAGE.md
+++ b/docs/ROLE-USAGE.md
@@ -1,6 +1,6 @@
 # Role-Based Access Control Usage
 
-This document explains how to use the role-based access control system in the Casino Liga application.
+This document explains how to use the role-based access control system in the Padeliga application.
 
 ## User Roles
 

--- a/docs/SCHEDULE-MANAGEMENT-FEATURES.md
+++ b/docs/SCHEDULE-MANAGEMENT-FEATURES.md
@@ -1,6 +1,6 @@
 # Schedule Management Features
 
-This document outlines the schedule generation and management functionality implemented in Casino Liga.
+This document outlines the schedule generation and management functionality implemented in Padeliga.
 
 ## Overview
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,6 +1,6 @@
 # Testing Guide for Role-Based Access Control
 
-This document provides guidelines for testing the role-based access control system in the Casino Liga application.
+This document provides guidelines for testing the role-based access control system in the Padeliga application.
 
 ## Prerequisites
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "casino-liga",
+  "name": "padeliga",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/src/app/auth/invite/page.tsx
+++ b/src/app/auth/invite/page.tsx
@@ -145,7 +145,7 @@ export default function InvitePage() {
             </h1>
             {playerInfo && (
               <p className="mt-2 text-gray-600 dark:text-gray-300">
-                You've been invited to join Casino Liga!
+                You've been invited to join Padeliga!
               </p>
             )}
           </div>

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -19,8 +19,9 @@ export default function DashboardLayout({
       <div className="hidden md:flex md:w-64 md:flex-col fixed inset-y-0">
         <div className="flex flex-col flex-grow border-r border-border bg-card">
           <div className="flex h-16 flex-shrink-0 items-center px-4 border-b">
-            <Link href="/dashboard" className="flex items-center space-x-2">
-              <span className="text-xl font-bold">Casino Liga</span>
+            <Link href="/dashboard" className="flex flex-col items-start">
+              <span className="text-xl font-bold">Padeliga</span>
+              <span className="text-xs text-muted-foreground italic">Tu liga. Tu juego.</span>
             </Link>
           </div>
           <div className="flex flex-col flex-grow overflow-y-auto pt-5 pb-4 px-4">
@@ -46,8 +47,9 @@ export default function DashboardLayout({
       {/* Mobile header */}
       <div className="md:hidden flex flex-col flex-1">
         <div className="sticky top-0 z-10 flex h-16 flex-shrink-0 items-center bg-card px-4 border-b border-border">
-          <Link href="/dashboard" className="flex items-center space-x-2">
-            <span className="text-xl font-bold">Casino Liga</span>
+          <Link href="/dashboard" className="flex flex-col items-start">
+            <span className="text-xl font-bold">Padeliga</span>
+            <span className="text-xs text-muted-foreground italic">Tu liga. Tu juego.</span>
           </Link>
           <div className="flex flex-1 justify-end items-center space-x-4">
             <ThemeToggle />

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -16,7 +16,7 @@ function DashboardPage() {
         
         <div className="mt-8">
           <Card className="p-6">
-            <h1 className="text-2xl font-bold mb-4">Welcome to Casino Liga!</h1>
+            <h1 className="text-2xl font-bold mb-4">Welcome to Padeliga!</h1>
             
             <div className="space-y-4">
               <p className="text-lg">
@@ -24,7 +24,7 @@ function DashboardPage() {
               </p>
               
               <p>
-                Welcome to the Casino Padel League! This is your dashboard where you can 
+                Welcome to Padeliga! This is your dashboard where you can 
                 create your player profile, join or create teams, participate in leagues,
                 and track your match results and rankings.
               </p>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,8 +10,8 @@ import { Toaster } from 'sonner';
 const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
-  title: 'Casino Liga - Padel League Management',
-  description: 'Organize, manage, and track your padel leagues with ease',
+  title: 'Padeliga - Padel League Management',
+  description: 'Tu liga. Tu juego. | Organize, manage, and track your padel leagues with ease',
 };
 
 export default async function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,7 +18,7 @@ export default function Home() {
         <div className="container mx-auto px-4 py-3 flex items-center justify-between">
           <div className="flex items-center">
             <Link href="/" className="text-xl font-bold">
-              Casino Liga
+              Padeliga
             </Link>
           </div>
           
@@ -276,7 +276,7 @@ export default function Home() {
         <div className="container mx-auto px-4 text-center">
           <h2 className="text-3xl font-bold mb-4">Ready to Organize Your Padel League?</h2>
           <p className="text-xl max-w-2xl mx-auto mb-8 text-muted-foreground">
-            Join thousands of padel players and organizers who trust Casino Liga to run their competitions.
+            Join thousands of padel players and organizers who trust Padeliga to run their competitions.
           </p>
           <Button size="lg" asChild>
             <Link href={session ? "/dashboard" : "/signup"}>
@@ -292,7 +292,7 @@ export default function Home() {
           <div className="flex flex-col md:flex-row justify-between items-center">
             <div className="mb-4 md:mb-0">
               <p className="text-sm text-muted-foreground">
-                &copy; {new Date().getFullYear()} Casino Liga. All rights reserved.
+                &copy; {new Date().getFullYear()} Padeliga. All rights reserved.
               </p>
             </div>
             <div className="flex space-x-4">

--- a/src/components/auth/AuthLogo.tsx
+++ b/src/components/auth/AuthLogo.tsx
@@ -4,8 +4,12 @@ import React from "react";
 
 const AuthLogo = () => (
   <div className="flex flex-col items-center mb-8 select-none">
-    <div className="flex items-center justify-center mb-4 rounded-full bg-primary/10">
-      <img src="/logo-placeholder-image.png" alt="Logo" className="h-20" />
+    <div className="flex flex-col items-center">
+      <div className="flex items-center justify-center mb-2 rounded-full bg-primary/10">
+        <img src="/logo-placeholder-image.png" alt="Padeliga Logo" className="h-20" />
+      </div>
+      <h1 className="text-2xl font-bold mb-1">Padeliga</h1>
+      <p className="text-sm text-muted-foreground italic">Tu liga. Tu juego.</p>
     </div>
   </div>
 );

--- a/src/components/layout/PageHeader.tsx
+++ b/src/components/layout/PageHeader.tsx
@@ -14,10 +14,11 @@ export function PageHeader() {
           </div>
 
           {/* Center - logo and title */}
-          <div className="flex items-center gap-2">
+          <div className="flex flex-col items-center">
             <h1 className="text-2xl font-semibold text-foreground tracking-tight">
-              <img src="/logo-placeholder-image.png" alt="Logo" className=" h-10" />
+              <img src="/logo-placeholder-image.png" alt="Logo" className="h-10" />
             </h1>
+            <div className="text-sm text-muted-foreground italic">Tu liga. Tu juego.</div>
           </div>
 
           {/* Right side */}

--- a/src/config/database/loader.ts
+++ b/src/config/database/loader.ts
@@ -214,7 +214,7 @@ export function loadMongoDBConfig(): MongoDBConfig {
   const requiredConfig = {
     // URI - required
     uri: process.env.MONGODB_URI || "",
-    databaseName: process.env.MONGODB_DATABASE || "saas_db",
+    databaseName: process.env.MONGODB_DATABASE || "padeliga",
 
     // These always get default settings if not specified elsewhere
     maxRetries: parseInt(process.env.MONGODB_MAX_RETRIES || "5"), // Increased from 3 to 5

--- a/src/hooks/useTeamNameMode.ts
+++ b/src/hooks/useTeamNameMode.ts
@@ -5,7 +5,7 @@ import { getRandomTeamName } from '@/utils/teamNameSuggestions';
 export type TeamNameMode = 'manual' | 'sequential' | 'funny';
 
 // LocalStorage key
-const TEAM_NAME_MODE_KEY = 'casino-liga-team-name-mode';
+const TEAM_NAME_MODE_KEY = 'padeliga-team-name-mode';
 
 export const useTeamNameMode = () => {
   const [teamNameMode, setTeamNameMode] = useLocalStorage<TeamNameMode>(
@@ -21,9 +21,9 @@ export const useTeamNameMode = () => {
 
 export const useTeamName = (teamsCount: number = 0) => {
   const { teamNameMode } = useTeamNameMode();
-  const [teamName, setTeamName] = useLocalStorage<string>('casino-liga-team-name', '');
+  const [teamName, setTeamName] = useLocalStorage<string>('padeliga-team-name', '');
   const [nextSequentialLetter, setNextSequentialLetter] = useLocalStorage<string>(
-    'casino-liga-next-letter',
+    'padeliga-next-letter',
     'A'
   );
 

--- a/src/lib/services/email-service.ts
+++ b/src/lib/services/email-service.ts
@@ -24,11 +24,11 @@ export class EmailService {
       // In a real implementation, this would use an email service like SendGrid, AWS SES, etc.
       // For now, we'll just log the email that would be sent
       logger.info(`SENDING INVITATION EMAIL to ${player.email}:
-        Subject: You've been invited to join Casino Liga
+        Subject: You've been invited to join Padeliga
         Body: 
         Hello ${player.nickname},
         
-        You've been invited to join Casino Liga! Click the link below to create your account:
+        You've been invited to join Padeliga! Click the link below to create your account:
         ${invitationLink}
         
         This invitation will expire in 7 days.


### PR DESCRIPTION
## Rebranding to "Padeliga"

*Tu liga. Tu juego.*

This PR implements the rebranding from "Casino Liga" to "Padeliga" with the new tagline "Tu liga. Tu juego." (Your league. Your game.) as requested.

### Changes Made

- Updated all documentation files with new brand name
- Changed database name references from "casino_liga" to "padeliga"
- Updated UI components to display the new brand name and tagline
- Updated project name in package.json
- Updated page metadata and SEO content

### Testing Notes

- The application will now use a different database name ("padeliga" instead of "casino_liga")
- Existing users should not be affected besides seeing the new branding
- Local development setups will need to update their .env.local file with the new database name

Check the REBRANDING.md file for a detailed breakdown of all changes and next steps.

Closes #no-issue